### PR TITLE
Reverse the data fetch for US Daily Data.

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -33,7 +33,7 @@ export const fetchDailyData = async () => {
     try {
       const { data } = await axios.get('https://api.covidtracking.com/v1/us/daily.json');
   
-      return data.map(({ positive, recovered, death, dateChecked: date }) => ({ confirmed: positive, recovered, deaths: death, date }));
+      return data.reverse().map(({ positive, recovered, death, dateChecked: date }) => ({ confirmed: positive, recovered, deaths: death, date }));
     } catch (error) {
       return error;
     }


### PR DESCRIPTION
The chart is displaying backwards now (with the newest dates on the left, and the oldest dates on the right). This can be seen on the live demo.

After this commit, the data will be reversed to better match the tutorial.