### PR TITLE
Chart fixes

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -33,7 +33,7 @@ export const fetchDailyData = async () => {
     try {
       const { data } = await axios.get('https://api.covidtracking.com/v1/us/daily.json');
   
-      return data.map(({ positive, recovered, death, dateChecked: date }) => ({ confirmed: positive, recovered, deaths: death, date }));
+      return data.map(({ positive, death, dateChecked }) => ({ confirmed: positive, deaths: death, date: dateChecked }));
     } catch (error) {
       return error;
     }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -33,7 +33,13 @@ export const fetchDailyData = async () => {
     try {
       const { data } = await axios.get('https://api.covidtracking.com/v1/us/daily.json');
   
-      return data.map(({ positive, death, dateChecked }) => ({ confirmed: positive, deaths: death, date: dateChecked }));
+      return data
+        .map(({ positive, death, dateChecked }) => ({
+          confirmed: positive,
+          deaths: death,
+          date: dateChecked
+        }))
+        .reverse();
     } catch (error) {
       return error;
     }

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -55,14 +55,7 @@ const Chart = ({ data: { confirmed, recovered, deaths }, country }) => {
             borderColor: 'red',
             backgroundColor: 'rgba(255, 0, 0, 0.5)',
             fill: true,
-          },  {
-            data: dailyData.map((data) => data.recovered),
-            label: 'Recovered',
-            borderColor: 'green',
-            backgroundColor: 'rgba(0, 255, 0, 0.5)',
-            fill: true,
-          },
-          ],
+          }],
         }}
       />
     ) : null


### PR DESCRIPTION
- Removes `recovered` property from daily data (no data is provided by the API) and `recovered` dataset from the line chart
- Flips the line chart horizontally so it's left-to-right